### PR TITLE
Change download URL og version of dependency-check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM openjdk:14-ea-15-jdk-alpine AS jdk
 
 FROM php:7.4.9-alpine
 
-ARG DEPENDENCY_CHECK_VERSION=5.2.4
+ARG DEPENDENCY_CHECK_VERSION=6.0.2
 
 ENV JAVA_HOME /opt/openjdk-14
 ENV PATH $JAVA_HOME/bin:$PATH
@@ -22,7 +22,7 @@ RUN set -eux; \
         java --version;
 
 RUN cd /opt && \
-        wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-${DEPENDENCY_CHECK_VERSION}-release.zip && \
+        wget https://github.com/jeremylong/DependencyCheck/releases/download/v${DEPENDENCY_CHECK_VERSION}/dependency-check-${DEPENDENCY_CHECK_VERSION}-release.zip && \
         unzip dependency-check-${DEPENDENCY_CHECK_VERSION}-release.zip && \
         rm dependency-check-${DEPENDENCY_CHECK_VERSION}-release.zip
 


### PR DESCRIPTION
Dependency Check has moved their archive repository from Bintray to GitHub.

See [the release notes](https://github.com/jeremylong/DependencyCheck/releases/tag/v6.0.2#:~:text=The%20project%20is%20migrating%20from%20hosting%20the%20release%20archives%20on%20Bintray%20and%20moving%20them%20to%20Github%20under%20the%20assets%20for%20each%20release%20Please%20update%20any%20automation%20you%20have%20to%20point%20to%20the%20new%20location).

Bintray results in 403 HTTP errors now so we have to change the download URL.

The version we used to use (5.2.4) is not present for download at GitHub but gives a 403 on Bintray so we have to upgrade the version as well.