### PR TITLE
Add yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,16 @@ COPY --from=dependency-check /usr/share/dependency-check /opt/dependency-check
 
 COPY --from=build-env /opt/dependency-check-jira /opt/dependency-check-jira
 
+# Install yarn.
+ENV PATH /root/.yarn/bin:$PATH
+
+RUN apk update \
+  && apk add nodejs curl bash binutils tar \
+  && rm -rf /var/cache/apk/* \
+  && /bin/bash \
+  && touch ~/.bashrc \
+  && curl -o- -L https://yarnpkg.com/install.sh | bash \
+  && apk del curl tar binutils
+
 ENTRYPOINT ["/opt/dependency-check-jira/bin/checkdep"]
 CMD []


### PR DESCRIPTION
Apparently DependencyCheck requires yarn to check yarn projects now.
